### PR TITLE
Be able to handle queries from client without OpenTelemetry for SNS & SQS

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,4 @@ This solution contains a bunch of libraries aimed to help with OpenTelemetry int
 # How to use
 
 Please have a look at the description and usage examples on [wiki page](https://github.com/albumprinter/Albelli.OpenTelemetry/wiki)
+


### PR DESCRIPTION
The client may not pass OT headers. We should not fall with NRE in this case.