### PR TITLE
[CMO-1211] Downgrade netstandard 2.1 to 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,3 @@ This solution contains a bunch of libraries aimed to help with OpenTelemetry int
 # How to use
 
 Please have a look at the description and usage examples on [wiki page](https://github.com/albumprinter/Albelli.OpenTelemetry/wiki)
-

--- a/src/Albelli.OpenTelemetry.AspNetCore/Albelli.OpenTelemetry.AspNetCore.csproj
+++ b/src/Albelli.OpenTelemetry.AspNetCore/Albelli.OpenTelemetry.AspNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Albelli.OpenTelemetry.AspNetCore</AssemblyName>
     <RootNamespace>Albelli.OpenTelemetry.AspNetCore</RootNamespace>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
@@ -12,6 +12,7 @@
     <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <Version>0.0.1</Version>
+    <LangVersion>Latest</LangVersion>
   </PropertyGroup>
    
   <ItemGroup>

--- a/src/Albelli.OpenTelemetry.AspNetCore/Albelli.OpenTelemetry.AspNetCore.csproj
+++ b/src/Albelli.OpenTelemetry.AspNetCore/Albelli.OpenTelemetry.AspNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <AssemblyName>Albelli.OpenTelemetry.AspNetCore</AssemblyName>
     <RootNamespace>Albelli.OpenTelemetry.AspNetCore</RootNamespace>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/src/Albelli.OpenTelemetry.Core/Albelli.OpenTelemetry.Core.csproj
+++ b/src/Albelli.OpenTelemetry.Core/Albelli.OpenTelemetry.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Albelli.OpenTelemetry.Core</AssemblyName>
     <RootNamespace>Albelli.OpenTelemetry.Core</RootNamespace>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
@@ -12,6 +12,7 @@
     <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <Version>0.0.1</Version>
+    <LangVersion>Latest</LangVersion>
   </PropertyGroup>
    
   <ItemGroup>

--- a/src/Albelli.OpenTelemetry.Core/Albelli.OpenTelemetry.Core.csproj
+++ b/src/Albelli.OpenTelemetry.Core/Albelli.OpenTelemetry.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <AssemblyName>Albelli.OpenTelemetry.Core</AssemblyName>
     <RootNamespace>Albelli.OpenTelemetry.Core</RootNamespace>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/src/Albelli.OpenTelemetry.HttpClient/Albelli.OpenTelemetry.HttpClient.csproj
+++ b/src/Albelli.OpenTelemetry.HttpClient/Albelli.OpenTelemetry.HttpClient.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Albelli.OpenTelemetry.HttpClient</AssemblyName>
     <RootNamespace>Albelli.OpenTelemetry.HttpClient</RootNamespace>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
@@ -12,6 +12,7 @@
     <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <Version>0.0.1</Version>
+    <LangVersion>Latest</LangVersion>
   </PropertyGroup>
    
   <ItemGroup>

--- a/src/Albelli.OpenTelemetry.HttpClient/Albelli.OpenTelemetry.HttpClient.csproj
+++ b/src/Albelli.OpenTelemetry.HttpClient/Albelli.OpenTelemetry.HttpClient.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <AssemblyName>Albelli.OpenTelemetry.HttpClient</AssemblyName>
     <RootNamespace>Albelli.OpenTelemetry.HttpClient</RootNamespace>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/src/Albelli.OpenTelemetry.Lambda.SNSEvents/Albelli.OpenTelemetry.Lambda.SNSEvents.csproj
+++ b/src/Albelli.OpenTelemetry.Lambda.SNSEvents/Albelli.OpenTelemetry.Lambda.SNSEvents.csproj
@@ -12,6 +12,7 @@
     <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <Version>0.0.1</Version>
+    <LangVersion>Latest</LangVersion>
   </PropertyGroup>
    
   <ItemGroup>

--- a/src/Albelli.OpenTelemetry.Lambda.SQSEvents/Albelli.OpenTelemetry.Lambda.SQSEvents.csproj
+++ b/src/Albelli.OpenTelemetry.Lambda.SQSEvents/Albelli.OpenTelemetry.Lambda.SQSEvents.csproj
@@ -12,6 +12,7 @@
     <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <Version>0.0.1</Version>
+    <LangVersion>Latest</LangVersion>
   </PropertyGroup>
    
   <ItemGroup>

--- a/src/Albelli.OpenTelemetry.Logging/Albelli.OpenTelemetry.Logging.csproj
+++ b/src/Albelli.OpenTelemetry.Logging/Albelli.OpenTelemetry.Logging.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Albelli.OpenTelemetry.Logging</AssemblyName>
     <RootNamespace>Albelli.OpenTelemetry.Logging</RootNamespace>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
@@ -12,6 +12,7 @@
     <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <Version>0.0.1</Version>
+    <LangVersion>Latest</LangVersion>
   </PropertyGroup>
    
   <ItemGroup>

--- a/src/Albelli.OpenTelemetry.Logging/Albelli.OpenTelemetry.Logging.csproj
+++ b/src/Albelli.OpenTelemetry.Logging/Albelli.OpenTelemetry.Logging.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <AssemblyName>Albelli.OpenTelemetry.Logging</AssemblyName>
     <RootNamespace>Albelli.OpenTelemetry.Logging</RootNamespace>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/src/Albelli.OpenTelemetry.SNS/Albelli.OpenTelemetry.SNS.csproj
+++ b/src/Albelli.OpenTelemetry.SNS/Albelli.OpenTelemetry.SNS.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <AssemblyName>Albelli.OpenTelemetry.SNS</AssemblyName>
     <RootNamespace>Albelli.OpenTelemetry.SNS</RootNamespace>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/src/Albelli.OpenTelemetry.SNS/Albelli.OpenTelemetry.SNS.csproj
+++ b/src/Albelli.OpenTelemetry.SNS/Albelli.OpenTelemetry.SNS.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Albelli.OpenTelemetry.SNS</AssemblyName>
     <RootNamespace>Albelli.OpenTelemetry.SNS</RootNamespace>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
@@ -12,6 +12,7 @@
     <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <Version>0.0.1</Version>
+    <LangVersion>Latest</LangVersion>
   </PropertyGroup>
    
   <ItemGroup>

--- a/src/Albelli.OpenTelemetry.SQS/Albelli.OpenTelemetry.SQS.csproj
+++ b/src/Albelli.OpenTelemetry.SQS/Albelli.OpenTelemetry.SQS.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <AssemblyName>Albelli.OpenTelemetry.SQS</AssemblyName>
     <RootNamespace>Albelli.OpenTelemetry.SQS</RootNamespace>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/src/Albelli.OpenTelemetry.SQS/Albelli.OpenTelemetry.SQS.csproj
+++ b/src/Albelli.OpenTelemetry.SQS/Albelli.OpenTelemetry.SQS.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Albelli.OpenTelemetry.SQS</AssemblyName>
     <RootNamespace>Albelli.OpenTelemetry.SQS</RootNamespace>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
@@ -12,6 +12,7 @@
     <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <Version>0.0.1</Version>
+    <LangVersion>Latest</LangVersion>
   </PropertyGroup>
    
   <ItemGroup>


### PR DESCRIPTION
Resolves [CMO-1211](https://albumprinter.atlassian.net/browse/CMO-1211)

The current target framework doesn't work at .net framework projects.

Proposed changes:
- Add cross-targeting to `.netstandart2.0`

Links:
- https://docs.microsoft.com/en-us/dotnet/standard/library-guidance/cross-platform-targeting